### PR TITLE
Fix quote and numbers

### DIFF
--- a/src/byond-fetch.ts
+++ b/src/byond-fetch.ts
@@ -87,7 +87,7 @@ async function readResponse(socket: PromiseSocket<net.Socket>): Promise<string |
       if (payloadSize != 4) throw Error('Unexpected size for float')
 
       const data = await socket.read(payloadSize) as Buffer
-      return data.readFloatBE()
+      return data.readFloatLE()
     }
     case ResponseDataType.String: {
       const data = await socket.read(payloadSize) as Buffer

--- a/src/byond-fetch.ts
+++ b/src/byond-fetch.ts
@@ -35,7 +35,7 @@ enum ResponseDataType {
  */
 async function writeRequest(socket: PromiseSocket<net.Socket>, topic: string) {
   let parameters = topic;
-  if (parameters.charAt(0) !== '?') parameters = `'?${parameters}`;
+  if (parameters.charAt(0) !== '?') parameters = `?${parameters}`;
 
   const header = Buffer.from(HEADER_PREFIX)
 


### PR DESCRIPTION
Кавычка она там просто лишняя

С числами я думал что-то сложнее, но оказалось, что просто не тот порядок чтения:

![image](https://github.com/ss220-space/byond-fetch/assets/32931701/7f0d401e-a632-4685-af8f-7a68c860b7a7)
*(23 игрока на сервере)*